### PR TITLE
Update sample implementations to indicate `entries`/`values`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,8 @@ This proposal is about providing a sensitive default to the common operation of 
 For now in JS (instead of in spec prose), the essence of the proposal is captured in this snippet:
 
 ````js
-Map.prototype.toJSON = function(){
-  var o = Object.create(null); // to avoid __proto__ nonsense
-  for(let [k, v] of this.entries()){
-    o[k] = v;
-  }
-  return o;
+Map.prototype.toJSON = function toJSON() {
+  return [...Map.prototype.entries.call(this)];
 }
 ````
 
@@ -39,8 +35,8 @@ Map.prototype.toJSON = function(){
 Same as above.
 
 ````js
-Set.prototype.toJSON = function(){
-  return [...this];
+Set.prototype.toJSON = function toJSON() {
+  return [...Set.prototype.values.call(this)];
 }
 ````
 


### PR DESCRIPTION
This is per discussion in #1 and #2. I think that this change achieves the following:
- makes the `toJSON` methods not generic (they will throw when not given a proper `Map`/`Set` instance, via internal slot checking already specified in `Map#entries`/`Set#values`)
- doesn't overload `Symbol.iterator`, which means subclasses have to override `toJSON`, **not** `Symbol.iterator`, when they wish to change how a subclassed `Map`/`Set` is serialized to JSON
- simplifies spec language, as well as polyfill/shim implementations, by removing the requirement to enumerate edge cases when passed non-`Map`/non-`Set` values
